### PR TITLE
CI: Sync build workflows and pre-commit config

### DIFF
--- a/.codespell
+++ b/.codespell
@@ -1,8 +1,0 @@
-# SPDX-License-Identifier: Apache-2.0
-# SPDX-FileCopyrightText: 2025 The Linux Foundation
-
-# Codespell configuration file
-# Add words that should be ignored (not typos)
-
-# Legitimate file extensions and technical terms
-edn

--- a/.github/workflows/build-test-release.yaml
+++ b/.github/workflows/build-test-release.yaml
@@ -230,33 +230,98 @@ jobs:
             sbom-cyclonedx.xml
           retention-days: 45
 
-      - name: "Security scan with Grype (SARIF)"
-        # yamllint disable-line rule:line-length
-        uses: anchore/scan-action@e1165082ffb1fe366ebaf02d8526e7c4989ea9d2  # v7.4.0
-        id: grype-sarif
-        # The first Grype scan should not abort the job on failure so that
-        # subsequent steps can collect artefacts and display human-readable
-        # results; the final check step will fail the job if needed
-        continue-on-error: true
-        with:
-          sbom: "${{ steps.sbom.outputs.sbom_json_path }}"
-          output-format: "sarif"
-          output-file: "grype-results.sarif"
-          fail-build: "true"
+      - name: "SBOM summary"
+        run: |
+            # SBOM summary
+            {
+              echo "## SBOM Summary"
+              echo "SBOM count: ${{ steps.sbom.outputs.component_count }}"
+              echo "Tool used: ${{ steps.sbom.outputs.dependency_manager }}"
+            } >> "$GITHUB_STEP_SUMMARY"
 
-      - name: "Security scan with Grype (Text/Table)"
-        # yamllint disable-line rule:line-length
-        uses: anchore/scan-action@e1165082ffb1fe366ebaf02d8526e7c4989ea9d2  # v7.4.0
-        id: grype-table
-        if: always()
+  grype:
+    name: 'Grype Audit SBOM'
+    runs-on: ubuntu-latest
+    needs: 'sbom'
+    timeout-minutes: 10
+    permissions:
+      contents: read
+    steps:
+      # Harden the runner used by this workflow
+      # yamllint disable-line rule:line-length
+      - uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40  # v2.19.0
         with:
-          sbom: "${{ steps.sbom.outputs.sbom_json_path }}"
-          output-format: "table"
-          output-file: "grype-results.txt"
-          # This scan produces human-readable output only; fail-build
-          # is false because the SARIF scan above captures the pass/fail
-          # outcome, checked by the final "Check Grype scan results" step
-          fail-build: "false"
+          egress-policy: 'audit'
+
+      - name: "Download SBOM artefact"
+        # yamllint disable-line rule:line-length
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
+        with:
+          name: sbom-files
+
+      - name: "Install Grype"
+        id: grype
+        # yamllint disable-line rule:line-length
+        uses: anchore/scan-action/download-grype@e1165082ffb1fe366ebaf02d8526e7c4989ea9d2  # v7.4.0
+        with:
+          cache-db: "true"
+
+      # The NO_BLOCK_AUDIT_FAIL repository variable (when set to
+      # 'true') disables failure propagation so releases can proceed
+      # when blocked by newly discovered CVEs in transitive
+      # dependencies. Without the override, this step turns red in
+      # the workflow run's Actions/Checks UI and is the sole source
+      # of the job's failure annotation; the CVE table is printed
+      # directly into the step log by echoing grype-results.txt.
+      - name: "Grype audit SBOM"
+        id: grype-audit
+        env:
+          GRYPE_CMD: "${{ steps.grype.outputs.cmd }}"
+          NO_BLOCK_AUDIT_FAIL: >-
+            ${{ vars.NO_BLOCK_AUDIT_FAIL == 'true' }}
+        run: |
+            # Run grype once, emitting all three output formats
+            # Render the human-readable table in this step's log
+            set +e
+            "${GRYPE_CMD}" \
+              -o "sarif=grype-results.sarif" \
+              -o "json=grype-results.json" \
+              -o "table=grype-results.txt" \
+              --fail-on medium \
+              "sbom:sbom-cyclonedx.json"
+            grype_exit=$?
+            set -e
+
+            echo "--- Grype scan results ---"
+            if [ -f grype-results.txt ]; then
+              cat grype-results.txt
+            else
+              echo "No table output produced"
+            fi
+
+            # grype returns 2 when it finds vulnerabilities at or
+            # above the configured --fail-on threshold; any other
+            # non-zero exit is treated as a grype failure.
+            if [ "${grype_exit}" = "0" ]; then
+              echo "No vulnerabilities at or above 'medium'"
+              exit 0
+            fi
+            if [ "${grype_exit}" != "2" ]; then
+              echo "::error::Grype exited with code ${grype_exit}"
+              exit "${grype_exit}"
+            fi
+
+            if [ "${NO_BLOCK_AUDIT_FAIL}" = "true" ]; then
+              echo "::warning::Grype found vulnerabilities at or" \
+                "above the 'medium' threshold, but" \
+                "NO_BLOCK_AUDIT_FAIL is set so the job will not" \
+                "fail."
+              exit 0
+            fi
+            echo "::error::Grype found vulnerabilities at or above" \
+              "the 'medium' severity threshold. See the table" \
+              "above for the offending packages and CVEs."
+            exit 1
 
       - name: "Upload Grype scan results"
         # yamllint disable-line rule:line-length
@@ -266,45 +331,72 @@ jobs:
           name: grype-scan-results
           path: |
             grype-results.sarif
+            grype-results.json
             grype-results.txt
           retention-days: 90
+          if-no-files-found: warn
 
       - name: "Grype summary"
         if: always()
         run: |
-            # Grype summary
+            # Render a Markdown table of Grype matches in the job
+            # step summary. The CVE data is sourced from the JSON
+            # scan output (grype-results.json) and processed with
+            # jq so that multi-word cells cannot accidentally break
+            # the Markdown table column layout. Any literal pipe
+            # characters present in cell content are escaped.
             {
-              echo "## SBOM Summary"
-              echo "SBOM count: ${{ steps.sbom.outputs.component_count }}"
-              echo "Tool used: ${{ steps.sbom.outputs.dependency_manager }}"
-              echo ""
               echo "## Grype Vulnerability Scan"
-              if [ -f grype-results.txt ]; then
-                cat grype-results.txt
-              else
+              echo ""
+              if [ ! -f grype-results.json ]; then
                 echo "No scan results available"
+                exit 0
               fi
+              match_count=$(jq '.matches | length' grype-results.json)
+              if [ "${match_count}" = "0" ]; then
+                echo "No vulnerabilities found at or above the" \
+                  "configured severity threshold."
+                exit 0
+              fi
+              echo "Found ${match_count} matching Grype record(s)."
+              echo ""
+              echo "| Package | Installed | Fixed In | Type |" \
+                "Vulnerability | Severity | EPSS | Risk |"
+              echo "| --- | --- | --- | --- | --- | --- | --- | --- |"
+              jq -r '
+                def esc: tostring | gsub("\\|"; "\\|");
+                # Round a numeric value to two decimal places
+                # using half-up rounding via jq built-in `round`.
+                def round2: (. * 100 | round) / 100;
+                def epss_pct:
+                  ( .vulnerability.epss // [] ) as $e
+                  | if ($e | length) == 0 then "-"
+                    else ( $e[0].epss // 0 ) as $p
+                      | if $p == 0 then "0%"
+                        elif ($p * 100) < 0.01 then "<0.01%"
+                        else ( ($p * 100) | round2 | tostring
+                               + "%" ) end
+                    end;
+                def risk_fmt:
+                  .vulnerability.risk
+                  | if . == null then "-"
+                    elif type == "number" then
+                      (round2 | tostring)
+                    else (. | tostring) end;
+                .matches[] |
+                [ (.artifact.name // "-" | esc),
+                  (.artifact.version // "-" | esc),
+                  ( ( .vulnerability.fix.versions // [] )
+                    | if length == 0 then "-"
+                      else join(", ") end | esc ),
+                  (.artifact.type // "-" | esc),
+                  (.vulnerability.id // "-" | esc),
+                  (.vulnerability.severity // "-" | esc),
+                  epss_pct,
+                  risk_fmt
+                ] | "| " + join(" | ") + " |"
+              ' grype-results.json
             } >> "$GITHUB_STEP_SUMMARY"
-            if [ -f grype-results.txt ]; then
-              echo "--- Grype scan results ---"
-              cat grype-results.txt
-            fi
-
-      # Fails the job if Grype found vulnerabilities, unless the
-      # NO_BLOCK_AUDIT_FAIL repository variable is set to 'true'.
-      # This allows releases to proceed when blocked by newly
-      # discovered CVEs in transitive dependencies.
-      - name: "Check Grype scan results"
-        if: >-
-          steps.grype-sarif.outcome == 'failure'
-          && vars.NO_BLOCK_AUDIT_FAIL != 'true'
-        run: |
-            # Check Grype scan results
-            echo "::error::Grype found vulnerabilities" \
-              "at or above severity threshold"
-            echo "Review the Grype Summary above or download the" \
-              "grype-scan-results artifact for details"
-            exit 1
 
   # NOTE: PyPI (test and production) will reject duplicate uploads for the
   # same package version. This means the publishing steps below are NOT
@@ -318,6 +410,7 @@ jobs:
       - 'tag-validate'
       - 'python-tests'
       - 'python-audit'
+      - 'grype'
     environment:
       name: 'development'
     permissions:

--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -263,30 +263,99 @@ jobs:
             sbom-cyclonedx.xml
           retention-days: 45
 
-      - name: "Security scan with Grype (SARIF)"
-        # yamllint disable-line rule:line-length
-        uses: anchore/scan-action@e1165082ffb1fe366ebaf02d8526e7c4989ea9d2  # v7.4.0
-        id: grype-sarif
-        # The first Grype scan should not abort the job on failure so that
-        # subsequent steps can collect artefacts and display human-readable
-        # results; the final check step will fail the job if needed
-        continue-on-error: true
-        with:
-          sbom: "${{ steps.sbom.outputs.sbom_json_path }}"
-          output-format: "sarif"
-          output-file: "grype-results.sarif"
-          fail-build: "true"
+      - name: "SBOM summary"
+        run: |
+            # SBOM summary
+            {
+              echo "## SBOM Summary"
+              echo "SBOM count: ${{ steps.sbom.outputs.component_count }}"
+              echo "Tool used: ${{ steps.sbom.outputs.dependency_manager }}"
+            } >> "$GITHUB_STEP_SUMMARY"
 
-      - name: "Security scan with Grype (Text/Table)"
-        # yamllint disable-line rule:line-length
-        uses: anchore/scan-action@e1165082ffb1fe366ebaf02d8526e7c4989ea9d2  # v7.4.0
-        id: grype-table
-        if: always()
+  grype:
+    name: 'Grype Audit SBOM'
+    runs-on: ubuntu-latest
+    needs: 'sbom'
+    if: ${{ !cancelled() && needs.sbom.result == 'success' }}
+    timeout-minutes: 10
+    permissions:
+      contents: read
+    steps:
+      # Harden the runner used by this workflow
+      # yamllint disable-line rule:line-length
+      - uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40  # v2.19.0
         with:
-          sbom: "${{ steps.sbom.outputs.sbom_json_path }}"
-          output-format: "table"
-          output-file: "grype-results.txt"
-          fail-build: "false"
+          egress-policy: 'audit'
+
+      - name: "Download SBOM artefact"
+        # yamllint disable-line rule:line-length
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
+        with:
+          name: sbom-files
+
+      - name: "Install Grype"
+        id: grype
+        # yamllint disable-line rule:line-length
+        uses: anchore/scan-action/download-grype@e1165082ffb1fe366ebaf02d8526e7c4989ea9d2  # v7.4.0
+        with:
+          cache-db: "true"
+
+      # The NO_BLOCK_AUDIT_FAIL repository variable (when set to
+      # 'true') disables failure propagation so pull requests can
+      # proceed when blocked by newly discovered CVEs in transitive
+      # dependencies. Without the override, this step turns red in
+      # the PR Checks UI and is the sole source of the job's
+      # failure annotation; the CVE table is printed directly into
+      # the step log by echoing grype-results.txt.
+      - name: "Grype audit SBOM"
+        id: grype-audit
+        env:
+          GRYPE_CMD: "${{ steps.grype.outputs.cmd }}"
+          NO_BLOCK_AUDIT_FAIL: >-
+            ${{ vars.NO_BLOCK_AUDIT_FAIL == 'true' }}
+        run: |
+            # Run grype once, emitting all three output formats
+            # Render the human-readable table in this step's log
+            set +e
+            "${GRYPE_CMD}" \
+              -o "sarif=grype-results.sarif" \
+              -o "json=grype-results.json" \
+              -o "table=grype-results.txt" \
+              --fail-on medium \
+              "sbom:sbom-cyclonedx.json"
+            grype_exit=$?
+            set -e
+
+            echo "--- Grype scan results ---"
+            if [ -f grype-results.txt ]; then
+              cat grype-results.txt
+            else
+              echo "No table output produced"
+            fi
+
+            # grype returns 2 when it finds vulnerabilities at or
+            # above the configured --fail-on threshold; any other
+            # non-zero exit is treated as a grype failure.
+            if [ "${grype_exit}" = "0" ]; then
+              echo "No vulnerabilities at or above 'medium'"
+              exit 0
+            fi
+            if [ "${grype_exit}" != "2" ]; then
+              echo "::error::Grype exited with code ${grype_exit}"
+              exit "${grype_exit}"
+            fi
+
+            if [ "${NO_BLOCK_AUDIT_FAIL}" = "true" ]; then
+              echo "::warning::Grype found vulnerabilities at or" \
+                "above the 'medium' threshold, but" \
+                "NO_BLOCK_AUDIT_FAIL is set so the job will not" \
+                "fail."
+              exit 0
+            fi
+            echo "::error::Grype found vulnerabilities at or above" \
+              "the 'medium' severity threshold. See the table" \
+              "above for the offending packages and CVEs."
+            exit 1
 
       - name: "Upload Grype scan results"
         # yamllint disable-line rule:line-length
@@ -296,38 +365,69 @@ jobs:
           name: grype-scan-results
           path: |
             grype-results.sarif
+            grype-results.json
             grype-results.txt
           retention-days: 90
+          if-no-files-found: warn
 
       - name: "Grype summary"
         if: always()
         run: |
-            # Grype summary
+            # Render a Markdown table of output in step summary.
+            # The CVE data is sourced from the JSON scan output
+            # (grype-results.json) and processed with jq so that
+            # multi-word cells cannot accidentally break the
+            # Markdown table column layout. Any literal pipe
+            # characters present in cell content are escaped.
             {
-              echo "## SBOM Summary"
-              echo "SBOM count: ${{ steps.sbom.outputs.component_count }}"
-              echo "Tool used: ${{ steps.sbom.outputs.dependency_manager }}"
-              echo ""
               echo "## Grype Vulnerability Scan"
-              if [ -f grype-results.txt ]; then
-                cat grype-results.txt
-              else
+              echo ""
+              if [ ! -f grype-results.json ]; then
                 echo "No scan results available"
+                exit 0
               fi
+              match_count=$(jq '.matches | length' grype-results.json)
+              if [ "${match_count}" = "0" ]; then
+                echo "No vulnerabilities found at or above the" \
+                  "configured severity threshold."
+                exit 0
+              fi
+              echo "Found ${match_count} matching Grype record(s)."
+              echo ""
+              echo "| Package | Installed | Fixed In | Type |" \
+                "Vulnerability | Severity | EPSS | Risk |"
+              echo "| --- | --- | --- | --- | --- | --- | --- | --- |"
+              jq -r '
+                def esc: tostring | gsub("\\|"; "\\|");
+                # Round a numeric value to two decimal places
+                # using half-up rounding via jq built-in `round`.
+                def round2: (. * 100 | round) / 100;
+                def epss_pct:
+                  ( .vulnerability.epss // [] ) as $e
+                  | if ($e | length) == 0 then "-"
+                    else ( $e[0].epss // 0 ) as $p
+                      | if $p == 0 then "0%"
+                        elif ($p * 100) < 0.01 then "<0.01%"
+                        else ( ($p * 100) | round2 | tostring
+                               + "%" ) end
+                    end;
+                def risk_fmt:
+                  .vulnerability.risk
+                  | if . == null then "-"
+                    elif type == "number" then
+                      (round2 | tostring)
+                    else (. | tostring) end;
+                .matches[] |
+                [ (.artifact.name // "-" | esc),
+                  (.artifact.version // "-" | esc),
+                  ( ( .vulnerability.fix.versions // [] )
+                    | if length == 0 then "-"
+                      else join(", ") end | esc ),
+                  (.artifact.type // "-" | esc),
+                  (.vulnerability.id // "-" | esc),
+                  (.vulnerability.severity // "-" | esc),
+                  epss_pct,
+                  risk_fmt
+                ] | "| " + join(" | ") + " |"
+              ' grype-results.json
             } >> "$GITHUB_STEP_SUMMARY"
-            if [ -f grype-results.txt ]; then
-              echo "--- Grype scan results ---"
-              cat grype-results.txt
-            fi
-
-      - name: "Check Grype scan results"
-        if: >-
-          steps.grype-sarif.outcome == 'failure'
-          && vars.NO_BLOCK_AUDIT_FAIL != 'true'
-        run: |
-            # Check Grype scan results
-            echo "::error::Grype found vulnerabilities" \
-              "at or above severity threshold"
-            echo "Review the Grype Summary above or download the" \
-              "grype-scan-results artifact for details"
-            exit 1

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -70,6 +70,7 @@ repos:
           - types-PyYAML>=6.0.0
           - typer>=0.16.0
           - GitPython>=3.1.0
+          - typing_extensions>=4.0.0
 
   - repo: https://github.com/btford/write-good
     rev: ab66ce10136dfad5146e69e70f82a3efac8842c1 # frozen: v1.0.8
@@ -116,6 +117,7 @@ repos:
           - GitPython>=3.1.0
           - PyYAML>=6.0.0
           - typer>=0.16.0
+          - typing_extensions>=4.0.0
 
   - repo: https://github.com/lfreleng-actions/gha-workflow-linter
     rev: a7caf8f3a1a05688d1cee46615ff94def617e5a3  # frozen: v1.0.2

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,6 +3,8 @@
 # SPDX-FileCopyrightText: 2025 The Linux Foundation
 
 ci:
+  # pre-commit.ci sandbox prevents network calls; disable gha-workflow-linter
+  skip: [gha-workflow-linter]
   autofix_commit_msg: |
     Chore: pre-commit autofixes
 
@@ -50,7 +52,7 @@ repos:
         types: [yaml]
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: d1b833175a5d08a925900115526febd8fe71c98e  # frozen: v0.15.11
+    rev: b831c3dc5d27d9da294ae4e915773b99aa24a7c5  # frozen: v0.15.10
     hooks:
       - id: ruff
         files: ^(scripts|tests|custom_components)/.+\.py$
@@ -62,15 +64,12 @@ repos:
     rev: 0f369d245750787ce34997d464ed9605391a5283  # frozen: v1.20.1
     hooks:
       - id: mypy
-        files: ^src/
-        additional_dependencies: [types-requests, types-PyYAML, typer]
 
   - repo: https://github.com/btford/write-good
     rev: ab66ce10136dfad5146e69e70f82a3efac8842c1 # frozen: v1.0.8
     hooks:
       - id: write-good
         files: "\\.(rst|md|markdown|mdown|mkdn)$"
-        args: ["--no-tooWordy"]
 
   - repo: https://github.com/shellcheck-py/shellcheck-py
     rev: 745eface02aef23e168a8afb6b5737818efbea95  # frozen: v0.11.0.1
@@ -100,11 +99,23 @@ repos:
     rev: 2ccb47ff45ad361a21071a7eedda4c37e6ae8c5a  # frozen: v2.4.2
     hooks:
       - id: codespell
-        args: ["--ignore-words=.codespell"]
 
-  - repo: https://github.com/python-jsonschema/check-jsonschema.git
+  # Requires a mirror, primary repo lacks .pre-commit-hooks.yaml
+  - repo: https://github.com/DetachHead/basedpyright-prek-mirror
+    rev: 7664ed7e31234c8369d85ee9a13a1ca3361c0aa1  # frozen: 1.39.0
+    hooks:
+      - id: basedpyright
+
+  - repo: https://github.com/lfreleng-actions/gha-workflow-linter
+    rev: a7caf8f3a1a05688d1cee46615ff94def617e5a3  # frozen: v1.0.2
+    hooks:
+      - id: gha-workflow-linter
+
+  - repo: https://github.com/python-jsonschema/check-jsonschema
     rev: ed81924a8b1cecdaa570b072528fa80c9c4d6ccd  # frozen: 0.37.1
     hooks:
+      - id: check-github-actions
+      - id: check-github-workflows
       - id: check-jsonschema
         name: Check GitHub Workflows set timeout-minutes
         args:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,7 +4,8 @@
 
 ci:
   # pre-commit.ci sandbox prevents network calls; disable gha-workflow-linter
-  skip: [gha-workflow-linter]
+  # basedpyright also requires network access to resolve deps
+  skip: [gha-workflow-linter, basedpyright]
   autofix_commit_msg: |
     Chore: pre-commit autofixes
 
@@ -52,7 +53,7 @@ repos:
         types: [yaml]
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: b831c3dc5d27d9da294ae4e915773b99aa24a7c5  # frozen: v0.15.10
+    rev: d1b833175a5d08a925900115526febd8fe71c98e  # frozen: v0.15.11
     hooks:
       - id: ruff
         files: ^(scripts|tests|custom_components)/.+\.py$
@@ -64,6 +65,11 @@ repos:
     rev: 0f369d245750787ce34997d464ed9605391a5283  # frozen: v1.20.1
     hooks:
       - id: mypy
+        files: ^src/.+\.py$
+        additional_dependencies:
+          - types-PyYAML>=6.0.0
+          - typer>=0.16.0
+          - GitPython>=3.1.0
 
   - repo: https://github.com/btford/write-good
     rev: ab66ce10136dfad5146e69e70f82a3efac8842c1 # frozen: v1.0.8
@@ -105,6 +111,11 @@ repos:
     rev: 7664ed7e31234c8369d85ee9a13a1ca3361c0aa1  # frozen: 1.39.0
     hooks:
       - id: basedpyright
+        files: ^src/.+\.py$
+        additional_dependencies:
+          - GitPython>=3.1.0
+          - PyYAML>=6.0.0
+          - typer>=0.16.0
 
   - repo: https://github.com/lfreleng-actions/gha-workflow-linter
     rev: a7caf8f3a1a05688d1cee46615ff94def617e5a3  # frozen: v1.0.2

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ semantic versioning rules.
 increment type
 - **Semantic versioning compliant**: Follows [SemVer](https://semver.org/)
 specification
-- **Complex pre-release support**: Handles multiple pre-release identifiers
+- **Complex pre-release support**: Handles compound pre-release identifiers
 - **GitHub Actions integration**: Easy to use in CI/CD workflows
 - **Conflict detection**: Optional checking against existing Git tags
 - **Flexible output formats**: Full version with prefix or numeric output
@@ -121,23 +121,23 @@ Use the `--validate` flag to check if a tag is a valid
 semantic version without incrementing:
 
 ```bash
-# Validate basic version
+# Check basic version
 semantic-tag-increment --tag "v1.2.3" --validate
 
-# Validate complex version with prerelease and metadata
+# Check complex version with prerelease and metadata
 semantic-tag-increment --tag "v1.2.3-alpha.1+build.123" --validate
 ```
 
 #### Version Validation
 
 ```bash
-# Validate a semantic version
+# Check a semantic version
 semantic-tag-increment --tag "v1.2.3-alpha.1" --validate
 ```
 
 #### Get Version Suggestions
 
-Use the `--suggest` flag to see multiple possible next versions:
+Use the `--suggest` flag to list candidate next versions:
 
 ```bash
 # Get suggestions for prerelease versions (default when using --suggest)
@@ -158,8 +158,8 @@ semantic-tag-increment --tag "v1.2.3" --increment "patch" --suggest
 - `--prerelease-type, -p`: Custom prerelease identifier (alpha, beta, rc, etc.)
 - `--preserve-metadata/--no-preserve-metadata`: Preserve or strip build metadata
   during increments (default: strip)
-- `--validate`: Validate the semantic version tag format without incrementing
-- `--suggest`: Show multiple possible next versions for the given increment type
+- `--validate`: Check the semantic version tag format without incrementing
+- `--suggest`: List candidate next versions for the given increment type
 - `--check-conflicts/--no-check-conflicts`: Enable/disable Git tag conflict
   checking
 - `--output-format, -f`: Output format: full, numeric, both (default: full)

--- a/action.yaml
+++ b/action.yaml
@@ -63,7 +63,7 @@ runs:
 
     - name: 'Setup Python'
       # yamllint disable rule:line-length
-      uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v5.3.0
+      uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
       with:
         python-version-file: "pyproject.toml"
         # No automatic caching

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -138,6 +138,34 @@ precision = 2
 [tool.coverage.html]
 directory = "coverage_html_report"
 
+[tool.basedpyright]
+include = ["src"]
+pythonVersion = "3.10"
+# basedpyright defaults are extremely strict; relax the warnings that
+# would otherwise require a sweeping refactor of the existing codebase.
+reportDeprecated = "none"
+reportExplicitAny = "none"
+reportAny = "none"
+reportUnknownMemberType = "none"
+reportUnknownVariableType = "none"
+reportUnknownArgumentType = "none"
+reportUnknownParameterType = "none"
+reportUnknownLambdaType = "none"
+reportMissingParameterType = "none"
+reportMissingTypeArgument = "none"
+reportUnannotatedClassAttribute = "none"
+reportImplicitOverride = "none"
+reportImplicitStringConcatenation = "none"
+reportUnnecessaryIsInstance = "none"
+reportUnusedCallResult = "none"
+reportUnusedParameter = "none"
+reportUnusedImport = "none"
+reportUnreachable = "none"
+reportUntypedFunctionDecorator = "none"
+reportUnsafeMultipleInheritance = "none"
+reportReturnType = "none"
+reportMissingSuperCall = "none"
+
 [tool.mypy]
 python_version = "3.10"
 warn_return_any = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,6 +48,7 @@ dependencies = [
     "typer>=0.16.0",
     "GitPython>=3.1.0",
     "PyYAML>=6.0.0",
+    "typing_extensions>=4.0.0",
 ]
 dynamic = ["version"]
 
@@ -141,30 +142,6 @@ directory = "coverage_html_report"
 [tool.basedpyright]
 include = ["src"]
 pythonVersion = "3.10"
-# basedpyright defaults are extremely strict; relax the warnings that
-# would otherwise require a sweeping refactor of the existing codebase.
-reportDeprecated = "none"
-reportExplicitAny = "none"
-reportAny = "none"
-reportUnknownMemberType = "none"
-reportUnknownVariableType = "none"
-reportUnknownArgumentType = "none"
-reportUnknownParameterType = "none"
-reportUnknownLambdaType = "none"
-reportMissingParameterType = "none"
-reportMissingTypeArgument = "none"
-reportUnannotatedClassAttribute = "none"
-reportImplicitOverride = "none"
-reportImplicitStringConcatenation = "none"
-reportUnnecessaryIsInstance = "none"
-reportUnusedCallResult = "none"
-reportUnusedParameter = "none"
-reportUnusedImport = "none"
-reportUnreachable = "none"
-reportUntypedFunctionDecorator = "none"
-reportUnsafeMultipleInheritance = "none"
-reportReturnType = "none"
-reportMissingSuperCall = "none"
 
 [tool.mypy]
 python_version = "3.10"

--- a/src/semantic_tag_increment/app_context.py
+++ b/src/semantic_tag_increment/app_context.py
@@ -27,7 +27,9 @@ class AppContext:
 class ContextDetector:
     """Detects and configures application execution context."""
 
-    CLI_COMMANDS = {"increment", "validate", "suggest", "help", "--help", "-h"}
+    CLI_COMMANDS: frozenset[str] = frozenset(
+        {"increment", "validate", "suggest", "help", "--help", "-h"}
+    )
 
     @staticmethod
     def detect_context() -> AppContext:

--- a/src/semantic_tag_increment/cli_interface.py
+++ b/src/semantic_tag_increment/cli_interface.py
@@ -11,7 +11,7 @@ focused solely on semantic tag incrementing without project detection.
 import logging
 import os
 import re
-from typing import Annotated, Optional
+from typing import Annotated
 
 import typer
 
@@ -40,13 +40,13 @@ def main_callback(
         typer.Option("--debug", help="Enable debug logging output to terminal"),
     ] = False,
     tag: Annotated[
-        Optional[str],
+        str | None,
         typer.Option(
             "--tag", "-t", help="The existing semantic tag to be incremented"
         ),
     ] = None,
     increment: Annotated[
-        Optional[str],
+        str | None,
         typer.Option(
             "--increment",
             "-i",
@@ -248,7 +248,7 @@ def suggest_versions_inline(tag: str, increment: str, path: str = ".", fetch_tim
 def increment_version(
     tag: str,
     increment: str = "dev",
-    prerelease_type: Optional[str] = None,
+    prerelease_type: str | None = None,
     check_conflicts: bool = True,
     output_format: str = "full",
     suppress_cli_logging: bool = False,
@@ -285,7 +285,7 @@ def _validate_increment_inputs(
     tag: str,
     increment: str,
     output_format: str,
-    prerelease_type: Optional[str],
+    prerelease_type: str | None,
     path: str,
     check_conflicts: bool
 ) -> None:
@@ -335,7 +335,7 @@ def _process_version_increment(
     mode: OperationMode,
     tag: str,
     increment: str,
-    prerelease_type: Optional[str],
+    prerelease_type: str | None,
     check_conflicts: bool,
     path: str,
     preserve_metadata: bool,

--- a/src/semantic_tag_increment/cli_interface.py
+++ b/src/semantic_tag_increment/cli_interface.py
@@ -164,7 +164,7 @@ def main_callback(
     # If no tag is provided and not validating or suggesting, show help
     if tag is None:
         typer.echo(ctx.get_help())
-        ctx.exit()
+        raise typer.Exit()
 
     # For increment mode, increment parameter is required
     if increment is None:

--- a/src/semantic_tag_increment/config.py
+++ b/src/semantic_tag_increment/config.py
@@ -10,9 +10,10 @@ Since the tool now only supports string mode, most configuration functionality h
 
 import logging
 import os
-import yaml
 from pathlib import Path
-from typing import Dict, Optional, Any
+from typing import ClassVar
+
+import yaml
 
 from .exceptions import ConfigurationError
 
@@ -28,18 +29,20 @@ class ConfigurationManager:
     """
 
     # Configuration directory and file names
-    CONFIG_DIR_NAME = "semantic_tag_increment"
-    USER_CONFIG_FILE = "config.yaml"
+    CONFIG_DIR_NAME: ClassVar[str] = "semantic_tag_increment"
+    USER_CONFIG_FILE: ClassVar[str] = "config.yaml"
 
-    def __init__(self, config_dir: Optional[str] = None):
+    def __init__(self, config_dir: str | None = None):
         """
         Initialize the configuration manager.
 
         Args:
             config_dir: Optional custom configuration directory path
         """
-        self.config_dir = Path(config_dir) if config_dir else self._get_default_config_dir()
-        self.user_config_file = self.config_dir / self.USER_CONFIG_FILE
+        self.config_dir: Path = (
+            Path(config_dir) if config_dir else self._get_default_config_dir()
+        )
+        self.user_config_file: Path = self.config_dir / self.USER_CONFIG_FILE
 
         # Ensure configuration directory exists
         self._ensure_config_dir()
@@ -59,9 +62,9 @@ class ConfigurationManager:
             self.config_dir.mkdir(parents=True, exist_ok=True)
             logger.debug(f"Configuration directory: {self.config_dir}")
         except OSError as e:
-            raise ConfigurationError(f"Failed to create configuration directory: {e}")
+            raise ConfigurationError(f"Failed to create configuration directory: {e}") from e
 
-    def load_general_config(self) -> Dict[str, Any]:
+    def load_general_config(self) -> dict[str, object]:
         """
         Load general configuration settings.
 
@@ -73,12 +76,19 @@ class ConfigurationManager:
 
         try:
             with open(self.user_config_file, 'r', encoding='utf-8') as f:
-                return yaml.safe_load(f) or {}
+                loaded: object = yaml.safe_load(f)  # pyright: ignore[reportAny]
+                if isinstance(loaded, dict):
+                    typed_loaded: dict[object, object] = {
+                        k: v
+                        for k, v in loaded.items()  # pyright: ignore[reportUnknownVariableType]
+                    }
+                    return {str(k): v for k, v in typed_loaded.items()}
+                return {}
         except Exception as e:
             logger.warning(f"Failed to load general configuration: {e}")
             return {}
 
-    def save_general_config(self, config: Dict[str, Any]) -> None:
+    def save_general_config(self, config: dict[str, object]) -> None:
         """
         Save general configuration settings.
 
@@ -94,14 +104,14 @@ class ConfigurationManager:
         except Exception as e:
             logger.warning(f"Failed to save general configuration: {e}")
 
-    def get_config_info(self) -> Dict[str, Any]:
+    def get_config_info(self) -> dict[str, object]:
         """
         Get information about the current configuration.
 
         Returns:
             Dictionary with configuration information
         """
-        info = {
+        info: dict[str, object] = {
             'config_dir': str(self.config_dir),
             'config_dir_exists': self.config_dir.exists(),
             'user_config_file': str(self.user_config_file),
@@ -117,7 +127,7 @@ class ConfigurationManager:
         Returns:
             List of validation issues (empty if no issues)
         """
-        issues = []
+        issues: list[str] = []
 
         # Check if configuration directory is writable
         if not os.access(self.config_dir, os.W_OK):
@@ -125,7 +135,7 @@ class ConfigurationManager:
 
         # Validate general configuration file
         try:
-            self.load_general_config()
+            _ = self.load_general_config()
         except Exception as e:
             issues.append(f"Failed to validate general configuration: {e}")
 
@@ -133,7 +143,7 @@ class ConfigurationManager:
 
 
 # Global configuration manager instance
-_config_manager: Optional[ConfigurationManager] = None
+_config_manager: ConfigurationManager | None = None
 
 
 def get_config_manager() -> ConfigurationManager:
@@ -144,7 +154,7 @@ def get_config_manager() -> ConfigurationManager:
     return _config_manager
 
 
-def initialize_config(config_dir: Optional[str] = None) -> ConfigurationManager:
+def initialize_config(config_dir: str | None = None) -> ConfigurationManager:
     """
     Initialize the configuration system.
 

--- a/src/semantic_tag_increment/exceptions.py
+++ b/src/semantic_tag_increment/exceptions.py
@@ -11,21 +11,25 @@ to improve error reporting and debugging throughout the application.
 import functools
 import logging
 import sys
-from typing import Any, Callable, Dict, TypeVar, NoReturn
+from collections.abc import Callable
+from typing import NoReturn, ParamSpec, TypeVar
 
 import click
 import typer
 
 logger = logging.getLogger(__name__)
 
-# Type variable for decorated functions
-F = TypeVar('F', bound=Callable[..., Any])
+# ParamSpec/TypeVar pair for preserving decorated callable signatures.
+P = ParamSpec("P")
+R = TypeVar("R")
 
 
 class SemanticVersionError(Exception):
     """Base exception for all semantic version operations."""
 
-    def __init__(self, message: str, details: dict[str, Any] | None = None):
+    def __init__(
+        self, message: str, details: dict[str, object] | None = None
+    ):
         """
         Initialize semantic version error.
 
@@ -34,74 +38,101 @@ class SemanticVersionError(Exception):
             details: Optional dictionary with additional error details
         """
         super().__init__(message)
-        self.details = details or {}
-        self.message = message
+        self.details: dict[str, object] = details or {}
+        self.message: str = message
 
 
 class ValidationError(SemanticVersionError):
     """Exception raised when validation fails."""
+
     pass
 
 
-class ParseError(ValueError, SemanticVersionError):
-    """Exception raised when parsing semantic version fails."""
-    pass
+class ParseError(  # pyright: ignore[reportUnsafeMultipleInheritance]
+    ValueError, SemanticVersionError
+):
+    """Exception raised when parsing semantic version fails.
+
+    Inherits from both ``ValueError`` (so existing ``except ValueError``
+    handlers continue to work) and ``SemanticVersionError`` (so it
+    participates in the project's typed error hierarchy). The dual
+    base classes share ``Exception`` as a common ancestor and the
+    initialiser below explicitly delegates to ``SemanticVersionError``
+    to set ``message``/``details``.
+    """
+
+    def __init__(
+        self, message: str, details: dict[str, object] | None = None
+    ):
+        """Initialise both parent classes with the supplied message."""
+        SemanticVersionError.__init__(self, message, details)
 
 
 class IncrementError(SemanticVersionError):
     """Exception raised when version increment operation fails."""
+
     pass
 
 
 class GitOperationError(SemanticVersionError):
     """Exception raised when git operations fail."""
+
     pass
 
 
 class ConfigurationError(SemanticVersionError):
     """Exception raised when configuration is invalid."""
+
     pass
 
 
 class SecurityError(SemanticVersionError):
     """Exception raised when security validation fails."""
+
     pass
 
 
 class ProjectDetectionError(SemanticVersionError):
     """Exception raised when project detection fails."""
+
     pass
 
 
 class VersionExtractionError(SemanticVersionError):
     """Exception raised when version extraction fails."""
+
     pass
 
 
-def handle_cli_errors(func: F) -> F:
+def handle_cli_errors(func: Callable[P, R]) -> Callable[P, R]:
     """
     Decorator for CLI command error handling.
 
     Provides consistent error handling and logging for CLI commands.
     """
+
     @functools.wraps(func)
-    def wrapper(*args: Any, **kwargs: Any) -> Any:
+    def wrapper(*args: P.args, **kwargs: P.kwargs) -> R:
         try:
             return func(*args, **kwargs)
         except SemanticVersionError as e:
-            return _handle_semantic_error_cli(e, func.__name__)
+            _handle_semantic_error_cli(e, func.__name__)
         except (typer.Exit, click.exceptions.Exit):
             # Re-raise Exit exceptions (including help, etc.)
             raise
         except Exception as e:
-            logger.error(f"Unexpected error in {func.__name__}: {e}", exc_info=True)
+            logger.error(
+                f"Unexpected error in {func.__name__}: {e}", exc_info=True
+            )
             typer.echo(f"Unexpected Error: {e}", err=True)
             raise typer.Exit(1) from e
 
-    return wrapper  # type: ignore[return-value]
+    return wrapper
 
 
-def _handle_semantic_error_cli(error: SemanticVersionError, func_name: str) -> None:
+def _handle_semantic_error_cli(
+    error: SemanticVersionError, func_name: str
+) -> NoReturn:
     """Handle semantic version errors for CLI commands."""
     error_type = type(error).__name__.replace("Error", "")
     logger.error(f"{error_type} error in {func_name}: {error}")
@@ -111,27 +142,28 @@ def _handle_semantic_error_cli(error: SemanticVersionError, func_name: str) -> N
     raise typer.Exit(1) from error
 
 
-def handle_github_actions_errors(func: F) -> F:
+def handle_github_actions_errors(func: Callable[P, R]) -> Callable[P, R]:
     """
     Decorator for GitHub Actions error handling.
 
     Provides consistent error handling for GitHub Actions mode.
     """
+
     @functools.wraps(func)
-    def wrapper(*args: Any, **kwargs: Any) -> Any:
+    def wrapper(*args: P.args, **kwargs: P.kwargs) -> R:
         try:
             return func(*args, **kwargs)
         except SemanticVersionError as e:
-            return _handle_semantic_error_gha(e)
+            _handle_semantic_error_gha(e)
         except Exception as e:
             logger.error(f"Unexpected error: {e}", exc_info=True)
             print(f"::error::Unexpected Error: {e}")
             sys.exit(1)
 
-    return wrapper  # type: ignore[return-value]
+    return wrapper
 
 
-def _handle_semantic_error_gha(error: SemanticVersionError) -> None:
+def _handle_semantic_error_gha(error: SemanticVersionError) -> NoReturn:
     """Handle semantic version errors for GitHub Actions."""
     error_type = type(error).__name__.replace("Error", "")
     logger.error(f"{error_type} error: {error}")
@@ -141,7 +173,9 @@ def _handle_semantic_error_gha(error: SemanticVersionError) -> None:
     sys.exit(1)
 
 
-def wrap_validation_error(original_error: Exception, context: str) -> ValidationError:
+def wrap_validation_error(
+    original_error: Exception, context: str
+) -> ValidationError:
     """
     Wrap a generic exception as a ValidationError with context.
 
@@ -157,12 +191,14 @@ def wrap_validation_error(original_error: Exception, context: str) -> Validation
         details={
             "original_error_type": type(original_error).__name__,
             "original_error_message": str(original_error),
-            "context": context
-        }
+            "context": context,
+        },
     )
 
 
-def wrap_parse_error(original_error: Exception, version_string: str) -> ParseError:
+def wrap_parse_error(
+    original_error: Exception, version_string: str
+) -> ParseError:
     """
     Wrap a generic exception as a ParseError with version context.
 
@@ -179,8 +215,8 @@ def wrap_parse_error(original_error: Exception, version_string: str) -> ParseErr
             "original_error_type": type(original_error).__name__,
             "original_error_message": str(original_error),
             "version_string": version_string,
-            "version_length": len(version_string) if version_string else 0
-        }
+            "version_length": len(version_string) if version_string else 0,
+        },
     )
 
 
@@ -188,7 +224,7 @@ def wrap_increment_error(
     original_error: Exception,
     version: str,
     increment_type: str,
-    prerelease_type: str | None = None
+    prerelease_type: str | None = None,
 ) -> IncrementError:
     """
     Wrap a generic exception as an IncrementError with operation context.
@@ -209,12 +245,14 @@ def wrap_increment_error(
             "original_error_message": str(original_error),
             "version": version,
             "increment_type": increment_type,
-            "prerelease_type": prerelease_type
-        }
+            "prerelease_type": prerelease_type,
+        },
     )
 
 
-def wrap_git_error(original_error: Exception, operation: str, path: str = ".") -> GitOperationError:
+def wrap_git_error(
+    original_error: Exception, operation: str, path: str = "."
+) -> GitOperationError:
     """
     Wrap a generic exception as a GitOperationError with operation context.
 
@@ -232,12 +270,14 @@ def wrap_git_error(original_error: Exception, operation: str, path: str = ".") -
             "original_error_type": type(original_error).__name__,
             "original_error_message": str(original_error),
             "operation": operation,
-            "path": path
-        }
+            "path": path,
+        },
     )
 
 
-def wrap_security_error(original_error: Exception, security_check: str, value: str) -> SecurityError:
+def wrap_security_error(
+    original_error: Exception, security_check: str, value: str
+) -> SecurityError:
     """
     Wrap a generic exception as a SecurityError with security context.
 
@@ -256,8 +296,8 @@ def wrap_security_error(original_error: Exception, security_check: str, value: s
             "original_error_message": str(original_error),
             "security_check": security_check,
             "value": value,
-            "value_length": len(value) if isinstance(value, str) else None
-        }
+            "value_length": len(value),
+        },
     )
 
 
@@ -265,7 +305,9 @@ class ErrorReporter:
     """Utility class for consistent error reporting."""
 
     @staticmethod
-    def log_and_raise_validation_error(message: str, details: dict[str, Any] | None = None) -> NoReturn:
+    def log_and_raise_validation_error(
+        message: str, details: dict[str, object] | None = None
+    ) -> NoReturn:
         """Log and raise a validation error."""
         error = ValidationError(message, details)
         logger.error(f"Validation error: {message}")
@@ -274,11 +316,13 @@ class ErrorReporter:
         raise error
 
     @staticmethod
-    def log_and_raise_parse_error(message: str, version_string: str) -> None:
+    def log_and_raise_parse_error(
+        message: str, version_string: str
+    ) -> NoReturn:
         """Log and raise a parse error."""
-        details = {
+        details: dict[str, object] = {
             "version_string": version_string,
-            "version_length": len(version_string) if version_string else 0
+            "version_length": len(version_string) if version_string else 0,
         }
         error = ParseError(message, details)
         logger.error(f"Parse error: {message}")
@@ -290,13 +334,13 @@ class ErrorReporter:
         message: str,
         version: str,
         increment_type: str,
-        prerelease_type: str | None = None
-    ) -> None:
+        prerelease_type: str | None = None,
+    ) -> NoReturn:
         """Log and raise an increment error."""
-        details = {
+        details: dict[str, object] = {
             "version": version,
             "increment_type": increment_type,
-            "prerelease_type": prerelease_type
+            "prerelease_type": prerelease_type,
         }
         error = IncrementError(message, details)
         logger.error(f"Increment error: {message}")
@@ -304,11 +348,13 @@ class ErrorReporter:
         raise error
 
     @staticmethod
-    def log_and_raise_git_error(message: str, operation: str, path: str = ".") -> None:
+    def log_and_raise_git_error(
+        message: str, operation: str, path: str = "."
+    ) -> NoReturn:
         """Log and raise a git operation error."""
-        details = {
+        details: dict[str, object] = {
             "operation": operation,
-            "path": path
+            "path": path,
         }
         error = GitOperationError(message, details)
         logger.error(f"Git operation error: {message}")
@@ -316,12 +362,14 @@ class ErrorReporter:
         raise error
 
     @staticmethod
-    def log_and_raise_security_error(message: str, security_check: str, value: str) -> None:
+    def log_and_raise_security_error(
+        message: str, security_check: str, value: str
+    ) -> NoReturn:
         """Log and raise a security error."""
-        details = {
+        details: dict[str, object] = {
             "security_check": security_check,
             "value": value,
-            "value_length": len(value) if isinstance(value, str) else None
+            "value_length": len(value),
         }
         error = SecurityError(message, details)
         logger.error(f"Security error: {message}")

--- a/src/semantic_tag_increment/git_operations.py
+++ b/src/semantic_tag_increment/git_operations.py
@@ -10,13 +10,13 @@ and other repository interactions using GitPython for native Git operations.
 
 import logging
 import os
-from typing import Set, Optional
-
-from .exceptions import ErrorReporter, GitOperationError, SecurityError
+from typing import ClassVar
 
 # Import GitPython (required dependency)
 import git
 from git.exc import GitCommandError, InvalidGitRepositoryError
+
+from .exceptions import ErrorReporter, GitOperationError, SecurityError
 
 logger = logging.getLogger(__name__)
 
@@ -28,11 +28,11 @@ class GitOperations:
     """Handles Git repository operations."""
 
     # Default fetch timeout in seconds
-    DEFAULT_FETCH_TIMEOUT = 120
+    DEFAULT_FETCH_TIMEOUT: ClassVar[int] = 120
 
     # Class-level cache for tag operations
-    _tag_cache: dict[str, set[str]] = {}
-    _cache_enabled: bool = True
+    _tag_cache: ClassVar[dict[str, set[str]]] = {}
+    _cache_enabled: ClassVar[bool] = True
 
     @staticmethod
     def _validate_path(path: str) -> str:
@@ -48,11 +48,11 @@ class GitOperations:
         Raises:
             ValueError: If path is invalid or doesn't exist
         """
-        if not path or not isinstance(path, str):
+        if not path:
             ErrorReporter.log_and_raise_security_error(
                 "Path must be a non-empty string",
                 "path_type_validation",
-                str(path)
+                str(path),
             )
 
         # Resolve to absolute path and check if it exists
@@ -61,18 +61,23 @@ class GitOperations:
             ErrorReporter.log_and_raise_security_error(
                 f"Path does not exist: {path}",
                 "path_existence_validation",
-                path
+                path,
             )
         if not os.path.isdir(abs_path):
             ErrorReporter.log_and_raise_security_error(
                 f"Path is not a directory: {path}",
                 "path_directory_validation",
-                path
+                path,
             )
         return abs_path
 
     @staticmethod
-    def get_existing_tags(path_prefix: str = ".", fetch_remote: bool = True, use_cache: bool = True, timeout: Optional[int] = None) -> Set[str]:
+    def get_existing_tags(
+        path_prefix: str = ".",
+        fetch_remote: bool = True,
+        use_cache: bool = True,
+        timeout: int | None = None,
+    ) -> set[str]:
         """
         Get existing git tags from the repository.
 
@@ -80,7 +85,8 @@ class GitOperations:
             path_prefix: Directory path containing the git repository
             fetch_remote: Whether to fetch tags from remote repository
             use_cache: Whether to use cached results if available
-            timeout: Timeout in seconds for remote fetch operations (defaults to DEFAULT_FETCH_TIMEOUT)
+            timeout: Timeout in seconds for remote fetch operations
+                (defaults to ``DEFAULT_FETCH_TIMEOUT``)
 
         Returns:
             Set of existing git tags, or empty set if unable to retrieve
@@ -95,11 +101,17 @@ class GitOperations:
 
         # Check cache first if enabled
         cache_key = f"{validated_path}:{fetch_remote}:{timeout}"
-        if use_cache and GitOperations._cache_enabled and cache_key in GitOperations._tag_cache:
+        if (
+            use_cache
+            and GitOperations._cache_enabled
+            and cache_key in GitOperations._tag_cache
+        ):
             logger.debug(f"Using cached tags for {validated_path}")
             return GitOperations._tag_cache[cache_key]
 
-        tags = GitOperations._get_tags_with_gitpython(validated_path, fetch_remote, timeout)
+        tags = GitOperations._get_tags_with_gitpython(
+            validated_path, fetch_remote, timeout
+        )
 
         # Cache the results if enabled
         if use_cache and GitOperations._cache_enabled:
@@ -109,7 +121,11 @@ class GitOperations:
         return tags
 
     @staticmethod
-    def _get_tags_with_gitpython(path_prefix: str, fetch_remote: bool = True, timeout: Optional[int] = None) -> Set[str]:
+    def _get_tags_with_gitpython(
+        path_prefix: str,
+        fetch_remote: bool = True,
+        timeout: int | None = None,
+    ) -> set[str]:
         """Get tags using GitPython library."""
         try:
             # Try to open the repository
@@ -118,18 +134,26 @@ class GitOperations:
             # Conditionally fetch tags from remote
             if fetch_remote and repo.remotes:
                 try:
-                    fetch_timeout = timeout if timeout is not None else GitOperations.DEFAULT_FETCH_TIMEOUT
-                    repo.remotes.origin.fetch(tags=True, timeout=fetch_timeout)
+                    fetch_timeout = (
+                        timeout
+                        if timeout is not None
+                        else GitOperations.DEFAULT_FETCH_TIMEOUT
+                    )
+                    _ = repo.remotes.origin.fetch(
+                        tags=True, timeout=fetch_timeout
+                    )
                     logger.debug("Fetched latest tags from remote")
                 except Exception as e:
                     logger.debug(f"Could not fetch tags from remote: {e}")
 
             # Get all tags
-            tags = set()
+            tags: set[str] = set()
             for tag_ref in repo.tags:
-                tags.add(tag_ref.name)
+                tags.add(str(tag_ref.name))
 
-            logger.debug(f"Found {len(tags)} existing git tags using GitPython")
+            logger.debug(
+                f"Found {len(tags)} existing git tags using GitPython"
+            )
             return tags
 
         except InvalidGitRepositoryError:
@@ -147,8 +171,8 @@ class GitOperations:
                 details={
                     "original_error_type": type(e).__name__,
                     "path": path_prefix,
-                    "operation": "get_tags_with_gitpython"
-                }
+                    "operation": "get_tags_with_gitpython",
+                },
             )
             logger.warning(f"Git operation failed: {git_error}")
             logger.info(NO_CONFLICT_CHECK_MSG)
@@ -177,7 +201,7 @@ class GitOperations:
     def _is_git_repo_with_gitpython(path_prefix: str) -> bool:
         """Check if directory is a Git repository using GitPython."""
         try:
-            git.Repo(path_prefix, search_parent_directories=True)
+            _ = git.Repo(path_prefix, search_parent_directories=True)
             return True
         except (InvalidGitRepositoryError, Exception):
             return False

--- a/src/semantic_tag_increment/github_actions.py
+++ b/src/semantic_tag_increment/github_actions.py
@@ -15,7 +15,7 @@ from typing import TypedDict
 from .app_context import GitHubActionsConfig
 from .exceptions import handle_github_actions_errors
 from .git_operations import GitOperations
-from .incrementer import VersionIncrementer
+from .incrementer import IncrementType, VersionIncrementer
 from .io_operations import IOOperations
 from .logging_config import LoggingConfig, SemanticLogger
 from .modes import ModeValidator, OperationMode
@@ -29,7 +29,7 @@ class IncrementResult(TypedDict):
 
     original_version: SemanticVersion
     incremented_version: SemanticVersion
-    increment_type: object
+    increment_type: IncrementType
     existing_tags: set[str]
 
 

--- a/src/semantic_tag_increment/github_actions.py
+++ b/src/semantic_tag_increment/github_actions.py
@@ -10,7 +10,7 @@ for string-mode tag incrementing only.
 
 import logging
 import time
-from typing import Any
+from typing import TypedDict
 
 from .app_context import GitHubActionsConfig
 from .exceptions import handle_github_actions_errors
@@ -18,10 +18,19 @@ from .git_operations import GitOperations
 from .incrementer import VersionIncrementer
 from .io_operations import IOOperations
 from .logging_config import LoggingConfig, SemanticLogger
-from .modes import OperationMode, ModeValidator
+from .modes import ModeValidator, OperationMode
 from .parser import SemanticVersion
 
 logger = logging.getLogger(__name__)
+
+
+class IncrementResult(TypedDict):
+    """Structured result returned by ``_execute_increment``."""
+
+    original_version: SemanticVersion
+    incremented_version: SemanticVersion
+    increment_type: object
+    existing_tags: set[str]
 
 
 class GitHubActionsRunner:
@@ -34,7 +43,7 @@ class GitHubActionsRunner:
         Args:
             debug_mode: Enable debug mode
         """
-        self.debug_mode = debug_mode
+        self.debug_mode: bool = debug_mode
         self._setup_logging()
 
     def _setup_logging(self) -> None:
@@ -123,7 +132,9 @@ class GitHubActionsRunner:
         print("::endgroup::")
         print()
 
-    def _execute_increment(self, config: dict[str, str | None]) -> dict[str, Any]:
+    def _execute_increment(
+        self, config: dict[str, str | None]
+    ) -> IncrementResult:
         """
         Execute the version increment operation.
 
@@ -218,7 +229,7 @@ class GitHubActionsRunner:
 
     def _output_results(
         self,
-        result: dict[str, Any]
+        result: IncrementResult,
     ) -> None:
         """Output results to GitHub Actions."""
         print("::group::Results")

--- a/src/semantic_tag_increment/incrementer.py
+++ b/src/semantic_tag_increment/incrementer.py
@@ -11,6 +11,7 @@ including smart pre-release handling and various increment strategies.
 import logging
 import re
 from enum import Enum
+from typing import ClassVar
 
 from .parser import SemanticVersion
 
@@ -37,19 +38,24 @@ class VersionIncrementer:
     """
 
     # Safety limits to prevent infinite loops and excessive search attempts
-    MAX_PATCH_ATTEMPTS = 100  # For searching available patch versions
-    MAX_PRERELEASE_ATTEMPTS = 1000  # For searching available prerelease versions
+    MAX_PATCH_ATTEMPTS: ClassVar[int] = 100
+    MAX_PRERELEASE_ATTEMPTS: ClassVar[int] = 1000
 
-    def __init__(self, existing_tags: set[str] | None = None, preserve_metadata: bool = False):
+    def __init__(
+        self,
+        existing_tags: set[str] | None = None,
+        preserve_metadata: bool = False,
+    ):
         """
         Initialize the version incrementer.
 
         Args:
             existing_tags: Set of existing version tags to avoid conflicts
-            preserve_metadata: Whether to preserve build metadata during increments
+            preserve_metadata: Whether to preserve build metadata during
+                increments
         """
-        self.existing_tags = existing_tags or set()
-        self.preserve_metadata = preserve_metadata
+        self.existing_tags: set[str] = existing_tags or set()
+        self.preserve_metadata: bool = preserve_metadata
         # Cache normalized tags for performance optimization
         self._normalized_tags_cache: set[str] | None = None
 
@@ -79,7 +85,9 @@ class VersionIncrementer:
         elif increment_type in (IncrementType.PRERELEASE, IncrementType.DEV):
             return self._increment_prerelease(version, prerelease_type)
         else:
-            raise ValueError(f"Unsupported increment type: {increment_type}")
+            raise ValueError(  # pyright: ignore[reportUnreachable]
+                f"Unsupported increment type: {increment_type}"
+            )
 
     def _increment_major(self, version: SemanticVersion) -> SemanticVersion:
         """Increment the major version and reset minor and patch."""
@@ -569,8 +577,8 @@ class VersionIncrementer:
             return aliases[increment_str]
 
         raise ValueError(
-            f"Invalid increment type: {increment_str}. "
-            f"Valid types: {[t.value for t in IncrementType]}"
+            f"Invalid increment type: {increment_str}."
+            + f" Valid types: {[t.value for t in IncrementType]}"
         )
 
     def suggest_next_version(
@@ -588,7 +596,7 @@ class VersionIncrementer:
         Returns:
             List of suggested next versions in order of preference
         """
-        suggestions = []
+        suggestions: list[SemanticVersion] = []
 
         if increment_type == IncrementType.PRERELEASE:
             # If current version is already a prerelease, suggest the next logical prerelease type
@@ -700,7 +708,7 @@ class VersionIncrementer:
         Returns:
             Set of existing patch numbers
         """
-        patches = set()
+        patches: set[int] = set()
         prefix_pattern = f"{major}.{minor}."
 
         for tag in self.existing_tags:
@@ -726,7 +734,7 @@ class VersionIncrementer:
         Returns:
             Set of existing prerelease numbers
         """
-        numbers = set()
+        numbers: set[int] = set()
         version_prefix = f"{major}.{minor}.{patch}-{prerelease_type}."
 
         for tag in self.existing_tags:

--- a/src/semantic_tag_increment/io_operations.py
+++ b/src/semantic_tag_increment/io_operations.py
@@ -9,8 +9,6 @@ This module handles file I/O operations and output formatting for different cont
 
 import logging
 import os
-from typing import Optional
-
 logger = logging.getLogger(__name__)
 
 
@@ -30,7 +28,7 @@ class IOOperations:
         if github_output:
             try:
                 with open(github_output, "a", encoding="utf-8") as f:
-                    f.write(f"{key}={value}\n")
+                    _ = f.write(f"{key}={value}\n")
                 logger.debug(f"Wrote GitHub output: {key}={value}")
             except OSError as e:
                 logger.error(f"Failed to write GitHub output: {e}")
@@ -50,7 +48,7 @@ class IOOperations:
         IOOperations.write_github_output("numeric_tag", numeric_version)
 
     @staticmethod
-    def get_env_var(name: str, default: Optional[str] = None) -> Optional[str]:
+    def get_env_var(name: str, default: str | None = None) -> str | None:
         """
         Get environment variable with optional default.
 

--- a/src/semantic_tag_increment/logging_config.py
+++ b/src/semantic_tag_increment/logging_config.py
@@ -11,7 +11,7 @@ GitHub Actions usage modes.
 import logging
 import time
 from pathlib import Path
-from typing import Any, Dict
+from typing import ClassVar
 
 
 class LoggingConfig:
@@ -69,10 +69,12 @@ class LoggingConfig:
 class SemanticLogger:
     """Utility class for consistent logging with semantic context."""
 
-    _operation_times: Dict[str, float] = {}
+    _operation_times: ClassVar[dict[str, float]] = {}
 
     @staticmethod
-    def operation_start(operation: str, details: Dict[str, Any] | None = None) -> None:
+    def operation_start(
+        operation: str, details: dict[str, object] | None = None
+    ) -> None:
         """
         Log the start of an operation with consistent formatting.
 
@@ -93,7 +95,9 @@ class SemanticLogger:
         SemanticLogger._operation_times[operation] = time.time()
 
     @staticmethod
-    def operation_success(operation: str, result: Dict[str, Any] | None = None) -> None:
+    def operation_success(
+        operation: str, result: dict[str, object] | None = None
+    ) -> None:
         """
         Log successful completion of an operation.
 
@@ -122,7 +126,11 @@ class SemanticLogger:
         logger.info(message)
 
     @staticmethod
-    def operation_error(operation: str, error: Exception, details: Dict[str, Any] | None = None) -> None:
+    def operation_error(
+        operation: str,
+        error: Exception,
+        details: dict[str, object] | None = None,
+    ) -> None:
         """
         Log an operation error with consistent formatting.
 
@@ -165,7 +173,7 @@ class SemanticLogger:
         logger.debug(f"Performance metric: {metric_name} = {value:.3f}{unit}")
 
     @staticmethod
-    def security_event(event_type: str, details: Dict[str, Any]) -> None:
+    def security_event(event_type: str, details: dict[str, object]) -> None:
         """
         Log a security-related event.
 

--- a/src/semantic_tag_increment/modes.py
+++ b/src/semantic_tag_increment/modes.py
@@ -89,6 +89,12 @@ class ModeHelper:
         Raises:
             ValidationError: If the mode string is not 'string'
         """
+        if not isinstance(mode_str, str):  # pyright: ignore[reportUnnecessaryIsInstance]
+            ErrorReporter.log_and_raise_validation_error(  # pyright: ignore[reportUnreachable]
+                "Mode must be a string,"
+                + f" got {type(mode_str).__name__}"
+            )
+
         if not mode_str:
             ErrorReporter.log_and_raise_validation_error(
                 "Mode must be a non-empty string"

--- a/src/semantic_tag_increment/modes.py
+++ b/src/semantic_tag_increment/modes.py
@@ -10,7 +10,7 @@ The tool now only supports string mode for direct tag incrementing.
 
 import logging
 from enum import Enum
-from typing import Optional, NoReturn
+from typing import NoReturn
 
 from .exceptions import ErrorReporter
 
@@ -29,9 +29,9 @@ class ModeValidator:
     @staticmethod
     def validate_mode_inputs(
         mode: OperationMode,
-        tag: Optional[str] = None,
-        path: Optional[str] = None,
-        check_tags: bool = True
+        tag: str | None = None,
+        path: str | None = None,
+        check_tags: bool = True,  # noqa: ARG004
     ) -> None:
         """
         Validate inputs for string mode.
@@ -45,8 +45,12 @@ class ModeValidator:
         Raises:
             ValidationError: If the inputs are invalid
         """
+        # ``check_tags`` is accepted for API compatibility but is not
+        # consulted here; it is honoured downstream by ``ModeHelper``.
+        _ = check_tags
+
         if mode != OperationMode.STRING:
-            ModeValidator._raise_unsupported_mode_error(mode)
+            ModeValidator._raise_unsupported_mode_error(mode)  # pyright: ignore[reportUnreachable]
 
         if not tag or not tag.strip():
             ErrorReporter.log_and_raise_validation_error(
@@ -63,7 +67,8 @@ class ModeValidator:
     def _raise_unsupported_mode_error(mode: OperationMode) -> NoReturn:
         """Raise an error for unsupported operation mode."""
         ErrorReporter.log_and_raise_validation_error(
-            f"Unsupported operation mode: {mode.value}. Only 'string' mode is supported."
+            f"Unsupported operation mode: {mode.value}."
+            + " Only 'string' mode is supported."
         )
 
 
@@ -84,15 +89,15 @@ class ModeHelper:
         Raises:
             ValidationError: If the mode string is not 'string'
         """
-        if not mode_str or not isinstance(mode_str, str):
+        if not mode_str:
             ErrorReporter.log_and_raise_validation_error(
                 "Mode must be a non-empty string"
             )
 
-        mode_str = mode_str.strip().lower()
+        normalised = mode_str.strip().lower()
 
-        if mode_str != "string":
-            ModeHelper._raise_invalid_mode_error(mode_str)
+        if normalised != "string":
+            ModeHelper._raise_invalid_mode_error(normalised)
 
         return OperationMode.STRING
 
@@ -107,17 +112,23 @@ class ModeHelper:
         Returns:
             Description string
         """
-        if mode == OperationMode.STRING:
+        # ``OperationMode`` only has a single member today, but the
+        # explicit branch keeps the API ready for future modes without
+        # tripping basedpyright's exhaustiveness checks.
+        if mode is OperationMode.STRING:
             return (
-                "String mode: Standalone tag incrementing based purely on input string. "
-                "No project context or file extraction is performed."
+                "String mode: Standalone tag incrementing based purely"
+                + " on input string. No project context or file extraction"
+                + " is performed."
             )
 
-        # This should never happen with current enum values, but keeping for future extensibility
-        raise ValueError(f"Unknown mode: {mode.value}")
+        # Defensive fallback for future enum members.
+        raise ValueError(f"Unknown mode: {mode.value}")  # pyright: ignore[reportUnreachable]
 
     @staticmethod
-    def should_check_git_tags(mode: OperationMode, check_tags: bool) -> bool:
+    def should_check_git_tags(
+        mode: OperationMode, check_tags: bool
+    ) -> bool:
         """
         Determine if Git tag checking should be performed.
 
@@ -128,14 +139,15 @@ class ModeHelper:
         Returns:
             True if Git tag checking should be performed
         """
-        if mode == OperationMode.STRING:
+        if mode is OperationMode.STRING:
             return check_tags
 
-        # This should never be reached with valid enum values
-        raise AssertionError(f"Unhandled mode: {mode}")
+        raise AssertionError(f"Unhandled mode: {mode}")  # pyright: ignore[reportUnreachable]
 
     @staticmethod
-    def get_effective_path(mode: OperationMode, path: Optional[str]) -> str:
+    def get_effective_path(
+        mode: OperationMode, path: str | None
+    ) -> str:
         """
         Get the effective path to use for Git operations.
 
@@ -146,15 +158,19 @@ class ModeHelper:
         Returns:
             The effective path to use (current directory for string mode)
         """
-        if mode == OperationMode.STRING:
-            # Use provided path or default to current directory for Git operations
+        if mode is OperationMode.STRING:
+            # Use provided path or default to current directory for Git
+            # operations.
             return path.strip() if path and path.strip() else "."
 
-        # This should never be reached with valid enum values
-        raise AssertionError(f"Unhandled mode: {mode}")
+        raise AssertionError(f"Unhandled mode: {mode}")  # pyright: ignore[reportUnreachable]
 
     @staticmethod
-    def log_mode_operation(mode: OperationMode, tag: Optional[str], path: Optional[str]) -> None:
+    def log_mode_operation(
+        mode: OperationMode,
+        tag: str | None,
+        path: str | None,
+    ) -> None:
         """
         Log information about the selected mode and operation.
 
@@ -163,14 +179,16 @@ class ModeHelper:
             tag: The input tag (required for string mode)
             path: The input path (used for Git operations)
         """
-        if mode == OperationMode.STRING:
-            logger.info(f"Operation mode: {mode.value}")
-            logger.debug(f"Mode description: {ModeHelper.get_mode_description(mode)}")
-            logger.info(f"Using explicit tag: {tag}")
-            if path and path.strip() and path.strip() != ".":
-                logger.info(f"Git operations path: {path}")
-        else:
-            raise AssertionError(f"Unhandled mode: {mode}")
+        if mode is not OperationMode.STRING:
+            raise AssertionError(f"Unhandled mode: {mode}")  # pyright: ignore[reportUnreachable]
+
+        logger.info(f"Operation mode: {mode.value}")
+        logger.debug(
+            f"Mode description: {ModeHelper.get_mode_description(mode)}"
+        )
+        logger.info(f"Using explicit tag: {tag}")
+        if path and path.strip() and path.strip() != ".":
+            logger.info(f"Git operations path: {path}")
 
     @staticmethod
     def _raise_invalid_mode_error(mode_str: str) -> NoReturn:

--- a/src/semantic_tag_increment/parser.py
+++ b/src/semantic_tag_increment/parser.py
@@ -11,6 +11,9 @@ with support for complex pre-release and metadata patterns.
 
 import re
 from dataclasses import dataclass
+from typing import ClassVar
+
+from typing_extensions import override
 
 from .exceptions import ErrorReporter
 
@@ -38,17 +41,19 @@ class SemanticVersion:
     # Optimized semantic version regex pattern for better performance
     # Compiled once at class definition for efficiency
     # Based on semver.org specification with performance optimizations
-    SEMVER_PATTERN = re.compile(
-        r"^(?P<prefix>[vV])?"
-        r"(?P<major>0|[1-9]\d*)"
-        r"\.(?P<minor>0|[1-9]\d*)"
-        r"\.(?P<patch>0|[1-9]\d*)"
-        r"(?:-(?P<prerelease>[0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?"
-        r"(?:\+(?P<metadata>[0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$",
-        re.ASCII  # Use ASCII flag to optimize regex performance for typical version strings.
-                  # This flag restricts the regex to ASCII-only characters, which improves performance
-                  # but makes it unsuitable for version strings containing Unicode characters. Ensure
-                  # that this limitation aligns with your use case before using this flag.
+    # Use ASCII flag to optimise regex performance for typical version
+    # strings. This flag restricts the regex to ASCII-only characters,
+    # which improves performance but makes it unsuitable for version
+    # strings containing Unicode characters. Ensure that this limitation
+    # aligns with your use case before using this flag.
+    SEMVER_PATTERN: ClassVar[re.Pattern[str]] = re.compile(
+        (
+            r"^(?P<prefix>[vV])?(?P<major>0|[1-9]\d*)"
+            + r"\.(?P<minor>0|[1-9]\d*)\.(?P<patch>0|[1-9]\d*)"
+            + r"(?:-(?P<prerelease>[0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?"
+            + r"(?:\+(?P<metadata>[0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$"
+        ),
+        re.ASCII,
     )
 
     @classmethod
@@ -65,16 +70,15 @@ class SemanticVersion:
         Raises:
             ValueError: If the version string is not a valid semantic version
         """
-        if not version_string or not isinstance(version_string, str):
+        if not version_string:
             raise ValueError("Version string cannot be empty or None")
 
         # Security check: prevent ReDoS attacks with overly long input
         if len(version_string) > MAX_VERSION_LENGTH:
             ErrorReporter.log_and_raise_security_error(
-                f"Version string too long (max {MAX_VERSION_LENGTH} characters): "
-                f"got {len(version_string)} characters",
+                f"Version string too long (max {MAX_VERSION_LENGTH} characters): got {len(version_string)} characters",
                 "input_length_validation",
-                version_string[:100] + "..." if len(version_string) > 100 else version_string
+                version_string[:100] + "..." if len(version_string) > 100 else version_string,
             )
 
         stripped_version = version_string.strip()
@@ -82,21 +86,17 @@ class SemanticVersion:
         # Additional security check after stripping
         if len(stripped_version) > MAX_VERSION_LENGTH:
             ErrorReporter.log_and_raise_security_error(
-                f"Version string too long after stripping (max {MAX_VERSION_LENGTH} characters): "
-                f"got {len(stripped_version)} characters",
+                f"Version string too long after stripping (max {MAX_VERSION_LENGTH} characters): got {len(stripped_version)} characters",
                 "stripped_length_validation",
-                stripped_version[:100] + "..." if len(stripped_version) > 100 else stripped_version
+                stripped_version[:100] + "..." if len(stripped_version) > 100 else stripped_version,
             )
 
         match = cls.SEMVER_PATTERN.match(stripped_version)
         if not match:
             ErrorReporter.log_and_raise_parse_error(
                 f"Invalid semantic version format: {version_string}",
-                version_string
+                version_string,
             )
-            # This return statement will never be reached due to the exception above
-            # but is needed to satisfy type checker
-            return cls(0, 0, 0)
 
         groups = match.groupdict()
 
@@ -112,11 +112,8 @@ class SemanticVersion:
         except (ValueError, TypeError) as e:
             ErrorReporter.log_and_raise_parse_error(
                 f"Invalid semantic version components: {e}",
-                version_string
+                version_string,
             )
-            # This return statement will never be reached due to the exception above
-            # but is needed to satisfy type checker
-            return cls(0, 0, 0)
 
     @classmethod
     def is_valid(cls, version_string: str) -> bool:
@@ -131,17 +128,18 @@ class SemanticVersion:
         """
         try:
             # Basic safety checks before attempting parse
-            if not version_string or not isinstance(version_string, str):
+            if not version_string:
                 return False
 
             if len(version_string) > MAX_VERSION_LENGTH:
                 return False
 
-            cls.parse(version_string)
+            _ = cls.parse(version_string)
             return True
         except (ValueError, TypeError):
             return False
 
+    @override
     def __str__(self) -> str:
         """Return the complete version string with prefix."""
         return self.to_string(include_prefix=True)
@@ -268,6 +266,7 @@ class SemanticVersion:
 
         return 0
 
+    @override
     def __eq__(self, other: object) -> bool:
         """Check equality based on version precedence (ignoring metadata)."""
         if not isinstance(other, SemanticVersion):
@@ -309,7 +308,7 @@ class SemanticVersion:
             List of tuples: (index, identifier, numeric_value)
             where index is the position in the pre-release identifier list
         """
-        numeric_components = []
+        numeric_components: list[tuple[int, str, int]] = []
         identifiers = self.get_prerelease_identifiers()
 
         for i, identifier in enumerate(identifiers):

--- a/src/semantic_tag_increment/parser.py
+++ b/src/semantic_tag_increment/parser.py
@@ -70,6 +70,12 @@ class SemanticVersion:
         Raises:
             ValueError: If the version string is not a valid semantic version
         """
+        if not isinstance(version_string, str):  # pyright: ignore[reportUnnecessaryIsInstance]
+            raise ValueError(  # pyright: ignore[reportUnreachable]
+                "Version string must be a string,"
+                + f" got {type(version_string).__name__}"
+            )
+
         if not version_string:
             raise ValueError("Version string cannot be empty or None")
 
@@ -128,6 +134,9 @@ class SemanticVersion:
         """
         try:
             # Basic safety checks before attempting parse
+            if not isinstance(version_string, str):  # pyright: ignore[reportUnnecessaryIsInstance]
+                return False  # type: ignore[unreachable]  # pyright: ignore[reportUnreachable]
+
             if not version_string:
                 return False
 

--- a/uv.lock
+++ b/uv.lock
@@ -553,6 +553,7 @@ dependencies = [
     { name = "gitpython" },
     { name = "pyyaml" },
     { name = "typer" },
+    { name = "typing-extensions" },
 ]
 
 [package.optional-dependencies]
@@ -590,6 +591,7 @@ requires-dist = [
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.15.11" },
     { name = "typer", specifier = ">=0.16.0" },
     { name = "types-pyyaml", marker = "extra == 'dev'", specifier = ">=6.0.0" },
+    { name = "typing-extensions", specifier = ">=4.0.0" },
 ]
 provides-extras = ["dev", "test"]
 


### PR DESCRIPTION
## Summary

Resync CI workflows and the pre-commit config with the current shared templates used across sibling projects.

### `build-test.yaml` / `build-test-release.yaml`
Synced from the `dependamerge` reference copy. The most important functional change is that both publishing jobs now forward the environment-scoped PyPI API tokens to `lfreleng-actions/pypi-publish-action`:

- `test-pypi` job: `pypi_credential: ${{ secrets.TEST_PYPI_CREDENTIAL }}` (development environment)
- `pypi` job: `pypi_credential: ${{ secrets.PYPI_CREDENTIAL }}` (production environment)

Without this, the action's fallback path exits with `GitHub credential NOT set/available: pypi_credential` — which is what happened on the most recent tag push ([run 23853242487](https://github.com/lfreleng-actions/semantic-tag-increment/actions/runs/23853242487/job/69539390763)). Trusted publishing can't kick in on the first release because auto mode requires the package to already exist on the index, so the static-token fallback is needed for the initial publish. Subsequent releases can switch to trusted publishing once it has been configured on (Test)PyPI.

### `.pre-commit-config.yaml`

Synced from `actions-template` then updates applied to setup/config the new listing
tools, and content updates made to ensure repository passes pre-commit/prek hooks.

## Test plan

- pre-commit hooks ran clean locally on both commits
- Confirmed the two `pypi_credential:` inputs appear in `build-test-release.yaml`