### PR TITLE
Fix(coverage): Use package name in coverage source list

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -113,7 +113,7 @@ markers = [
 ]
 
 [tool.coverage.run]
-source = ["src/semantic_tag_increment"]
+source = ["semantic_tag_increment"]
 omit = [
     "*/tests/*",
     "*/test_*",


### PR DESCRIPTION
## Summary

`[tool.coverage.run].source = ["src/semantic_tag_increment"]` is a filesystem path. coverage.py treats `source` entries with a path separator as path filters. Under `lfreleng-actions/python-test-action` v1.1.x, which installs the project **non-editably** into `.venv`, the package lives at `.venv/lib/pythonX.Y/site-packages/semantic_tag_increment/...` — a location the path filter never matches — so coverage reports `Total coverage: 0.00%` with a `No data was collected` warning, and any `--cov-fail-under` gate fails despite all tests passing.

## Fix

```diff
 [tool.coverage.run]
-source = ["src/semantic_tag_increment"]
+source = ["semantic_tag_increment"]
```

`coverage.py` treats single-token entries as import names and instruments the package wherever it is loaded from (including `site-packages`).

## Why this is actively broken (not latent)

The workflow is currently pinned to `python-test-action@734c129 # v1.1.1`. In v1.1.x:

- `addopts = [..., "--cov", ...]` (bare `--cov`) → `detect_coverage.py` sees `cov_in_addopts=true` → action does **not** inject anything additional.
- pytest then runs with the bare `--cov` from addopts plus `--cov-config=pyproject.toml`.
- The bare `--cov` falls back to `[tool.coverage.run].source` to scope collection.
- That source is `["src/semantic_tag_increment"]` — a path that never matches `site-packages`.

Result: `0.00%` coverage on every push to this repo's CI today. Switching to the import name fixes it.

(My original PR description incorrectly said "pinned to v1.0.2 / preventive change" — corrected here per Copilot review feedback.)

Related fixes: [`lfreleng-actions/markdown-table-fixer#129`](https://github.com/lfreleng-actions/markdown-table-fixer/pull/129) (where the regression first surfaced) and [`lfreleng-actions/gha-workflow-linter#196`](https://github.com/lfreleng-actions/gha-workflow-linter/pull/196).