### PR TITLE
Fix(deps): Declare click as a direct dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,6 +46,7 @@ keywords = [
 requires-python = ">=3.10,<3.14"
 dependencies = [
     "typer>=0.16.0",
+    "click>=8.0.0",
     "GitPython>=3.1.0",
     "PyYAML>=6.0.0",
     "typing_extensions>=4.0.0",

--- a/uv.lock
+++ b/uv.lock
@@ -44,6 +44,18 @@ wheels = [
 ]
 
 [[package]]
+name = "click"
+version = "8.4.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9b/98/518d8e5081007684232226f475082b30087d0f585e8457db087298259f49/click-8.4.1.tar.gz", hash = "sha256:918b5633eddf6b41c32d4f454bf0de810065c74e3f7dbf8ee5452f8be88d3e96", size = 353007, upload-time = "2026-05-22T04:08:37.769Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c7/0d/67e5b4109ea4a837e80daa87c2c696711955e40449a97e8926672534def2/click-8.4.1-py3-none-any.whl", hash = "sha256:482be17c6991b8c19c5429a1e995d9b0efdbb63172824c41f99965dc0ade8ec2", size = 116639, upload-time = "2026-05-22T04:08:35.26Z" },
+]
+
+[[package]]
 name = "colorama"
 version = "0.4.6"
 source = { registry = "https://pypi.org/simple" }
@@ -562,6 +574,7 @@ wheels = [
 name = "semantic-tag-increment"
 source = { editable = "." }
 dependencies = [
+    { name = "click" },
     { name = "gitpython" },
     { name = "pyyaml" },
     { name = "typer" },
@@ -588,6 +601,7 @@ test = [
 
 [package.metadata]
 requires-dist = [
+    { name = "click", specifier = ">=8.0.0" },
     { name = "coverage", extras = ["toml"], marker = "extra == 'dev'", specifier = ">=7.13.5" },
     { name = "coverage", extras = ["toml"], marker = "extra == 'test'", specifier = ">=7.13.5" },
     { name = "gitpython", specifier = ">=3.1.0" },


### PR DESCRIPTION
## Problem

CI is failing on `main` and on every recent PR (e.g. the Dependabot
ruff bump in #194). All Python test jobs across 3.10–3.13 fail at
pytest **collection** time with the same error:

```
ImportError while importing test module '.../tests/test_cli.py'.
    from .exceptions import handle_cli_errors, ErrorReporter
E   ModuleNotFoundError: No module named 'click'
```

This is unrelated to any individual dependency bump — it is an
environmental/transitive break.

## Root cause

`src/semantic_tag_increment/exceptions.py` does a direct
`import click`, but `click` was never declared in
`pyproject.toml` dependencies. It was only available transitively
through `typer`.

`typer` 0.26.x **dropped its `click` dependency** (its requires are
now `annotated-doc, rich, shellingham`). Because the CI test action
installs with `uv pip install ./[test,dev]` (resolving the latest
typer from PyPI) rather than `uv sync` against the pinned lock,
`click` is no longer pulled in and the direct import fails.

## Fix

- Declare `click>=8.0.0` as an explicit runtime dependency (it is a
  real, directly-imported dependency and should be declared
  regardless of typer's transitive behavior).
- Regenerate `uv.lock` so the direct dependency is recorded.

## Validation

- Reproduced the failure locally with a non-editable
  `uv pip install ./[test,dev]` (typer 0.26.7 installed, no click).
- Confirmed adding `click` restores the import.
- Full suite green locally: `210 passed`.
