### PR TITLE
Fix: restrict testing workflow permissions

### DIFF
--- a/.github/workflows/testing.yaml
+++ b/.github/workflows/testing.yaml
@@ -21,7 +21,7 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
-permissions: read-all
+permissions: {}
 
 jobs:
   basic-tests:
@@ -540,6 +540,7 @@ jobs:
   test-summary:
     name: 'Test Summary'
     runs-on: 'ubuntu-latest'
+    permissions: {}
     timeout-minutes: 2
     needs:
       - basic-tests


### PR DESCRIPTION
## Summary

Zizmor flagged the top-level `permissions: read-all` in
`.github/workflows/testing.yaml` as an `excessive-permissions` finding.
The broad workflow-level grant is unnecessary because each job can
declare its own minimal scope.

This change sets the top-level `permissions` to an empty map (`{}`) to
deny all scopes by default, matching the convention already used by the
other workflows in this repository (`build-test.yaml`, `codeql.yml`,
`release-drafter.yaml`, `build-test-release.yaml`, etc.).

It also adds an explicit `permissions: {}` to the `test-summary` job,
which previously relied on the workflow-level grant. That job only
echoes a summary table and inspects `needs.*.result`, so it requires no
token scopes. With this addition every job declares its own
least-privilege permissions explicitly.

## Rationale

- Resolves the Zizmor `zizmor/excessive-permissions` audit warning.
- No job behaviour changes: test jobs retain their explicit
  `contents: read`, and `test-summary` needs no scopes.
- Brings `testing.yaml` in line with the repository's established
  least-privilege permissions convention.

## Validation

- All `pre-commit` hooks pass (yamllint, actionlint, workflow validators).
