### PR TITLE
Fix: resolve Zizmor template-injection findings

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -52,12 +52,14 @@ runs:
   steps:
     - name: 'Setup action/environment'
       shell: bash
+      env:
+        INPUT_PATH: "${{ inputs.path }}"
       run: |
         # Setup action/environment
 
         # Verify path is a valid directory
-        if [ ! -d "${{ inputs.path }}" ]; then
-          echo 'Error: invalid path/directory ${{ inputs.path }} ❌'
+        if [ ! -d "$INPUT_PATH" ]; then
+          echo "Error: invalid path/directory $INPUT_PATH ❌"
           exit 1
         fi
 


### PR DESCRIPTION
## Pull request overview

Zizmor's regular-persona audit (the configuration used by the
organisation-level scheduled scan) reported `template-injection`
findings in this composite action. This change resolves them, bringing
the action to zero medium-or-higher findings.

### Changes

- **template-injection:** the "Setup action/environment" step
  interpolated `${{ inputs.path }}` directly into the bash `run` block
  (both the directory test and the error message). The value is now
  routed through a per-step `env:` block (`INPUT_PATH`) and referenced
  as a quoted shell variable so nothing user-controlled is expanded
  into a run body.

### Impact

No behavioural change.
