### PR TITLE
Fix: resolve zizmor auditor persona findings

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -27,9 +27,7 @@ jobs:
     # yamllint disable-line rule:line-length
     uses: lfit/releng-reusable-workflows/.github/workflows/reuse-python-codeql.yaml@50e324ef804880c13d4aebcefcac07ad81661d01 # v0.6.1
     permissions:
-      security-events: write
-      # required to fetch internal or private CodeQL packs
-      packages: read
-      # only required for workflows in private repositories
-      actions: read
+      security-events: write  # Upload CodeQL scan results
+      packages: read  # Fetch internal or private CodeQL packs
+      actions: read  # Only required for workflows in private repositories
       contents: read

--- a/.github/workflows/release-drafter.yaml
+++ b/.github/workflows/release-drafter.yaml
@@ -20,16 +20,26 @@ jobs:
   update_release_draft:
     name: 'Update Release Draft'
     permissions:
-      # write permission is required to create releases
-      contents: write
+      contents: write  # Create and update draft releases
     runs-on: 'ubuntu-latest'
     timeout-minutes: 3
     steps:
-      # Harden the runner used by this workflow
+      # Load the egress allow-list out-of-band from the
+      # organisation's .github repository and publish it as
+      # $CONNECTION_ALLOW_LIST for the harden-runner step below.
       # yamllint disable-line rule:line-length
-      - uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+      - uses: lfreleng-actions/harden-runner-block-action@6db537b3e6d060c3287c5a3ce2c28b55b0af330d  # v0.2.1
         with:
-          egress-policy: 'audit'
+          config: '@18d9c4446bea555d0783e850f6d295f844fe8f67'  # v0.1.1
+
+      # Harden the runner with the just-loaded allow-list.
+      - name: 'Harden runner (block)'
+        # yamllint disable-line rule:line-length
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411  # v2.19.4
+        with:
+          egress-policy: 'block'
+          allowed-endpoints: >
+            ${{ env.CONNECTION_ALLOW_LIST }}
 
       # yamllint disable-line rule:line-length
-      - uses: release-drafter/release-drafter@ed4bc48ec97379be2258e7b7ac2624a3e26ab809 # v7.4.0
+      - uses: release-drafter/release-drafter@4d75298e00d9e34c483e5ff8c68d0ea1c1940c1e  # v7.5.1

--- a/.github/workflows/testing.yaml
+++ b/.github/workflows/testing.yaml
@@ -40,6 +40,8 @@ jobs:
       - name: 'Checkout repository'
         # yamllint disable rule:line-length
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
 
       - name: "Basic increment: patch"
         id: basic-patch
@@ -140,6 +142,8 @@ jobs:
       - name: 'Checkout repository'
         # yamllint disable rule:line-length
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
 
       - name: "Prerelease with type: alpha"
         id: prerelease-alpha
@@ -237,6 +241,8 @@ jobs:
       - name: 'Checkout repository'
         # yamllint disable rule:line-length
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
 
       - name: "No prefix tag"
         id: no-prefix
@@ -352,6 +358,8 @@ jobs:
       - name: 'Checkout repository'
         # yamllint disable rule:line-length
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
 
       - name: "Invalid tag format"
         id: invalid-tag
@@ -418,6 +426,8 @@ jobs:
       - name: 'Checkout repository'
         # yamllint disable rule:line-length
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
 
       - name: "Test with V prefix"
         id: v-prefix
@@ -483,6 +493,8 @@ jobs:
       - name: 'Checkout repository'
         # yamllint disable rule:line-length
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
 
       # Test with conflict checking disabled for speed
       - name: "Fast execution without git checks"
@@ -553,26 +565,41 @@ jobs:
     steps:
       - name: 'Print test summary'
         shell: bash
+        env:
+          BASIC_RESULT: "${{ needs.basic-tests.result }}"
+          PRERELEASE_RESULT: "${{ needs.prerelease-tests.result }}"
+          EDGE_CASE_RESULT: "${{ needs.edge-case-tests.result }}"
+          ERROR_HANDLING_RESULT: "${{ needs.error-handling-tests.result }}"
+          OUTPUT_RESULT: "${{ needs.output-tests.result }}"
+          PERFORMANCE_RESULT: "${{ needs.performance-tests.result }}"
         run: |
+          status() {
+            if [ "$1" = "success" ]; then
+              echo "✅ Passed"
+            else
+              echo "❌ Failed"
+            fi
+          }
+
           echo "## 🧪 Test Summary"
           echo ""
           echo "| Test Suite | Result |"
           echo "|------------|--------|"
-          echo "| Basic Tests | ${{ needs.basic-tests.result == 'success' && '✅ Passed' || '❌ Failed' }} |"
-          echo "| Prerelease Tests | ${{ needs.prerelease-tests.result == 'success' && '✅ Passed' || '❌ Failed' }} |"
-          echo "| Edge Case Tests | ${{ needs.edge-case-tests.result == 'success' && '✅ Passed' || '❌ Failed' }} |"
-          echo "| Error Handling Tests | ${{ needs.error-handling-tests.result == 'success' && '✅ Passed' || '❌ Failed' }} |"
-          echo "| Output Tests | ${{ needs.output-tests.result == 'success' && '✅ Passed' || '❌ Failed' }} |"
-          echo "| Performance Tests | ${{ needs.performance-tests.result == 'success' && '✅ Passed' || '❌ Failed' }} |"
+          echo "| Basic Tests | $(status "$BASIC_RESULT") |"
+          echo "| Prerelease Tests | $(status "$PRERELEASE_RESULT") |"
+          echo "| Edge Case Tests | $(status "$EDGE_CASE_RESULT") |"
+          echo "| Error Handling Tests | $(status "$ERROR_HANDLING_RESULT") |"
+          echo "| Output Tests | $(status "$OUTPUT_RESULT") |"
+          echo "| Performance Tests | $(status "$PERFORMANCE_RESULT") |"
           echo ""
 
           # Exit with error if any test failed
-          if [ "${{ needs.basic-tests.result }}" != "success" ] || \
-             [ "${{ needs.prerelease-tests.result }}" != "success" ] || \
-             [ "${{ needs.edge-case-tests.result }}" != "success" ] || \
-             [ "${{ needs.error-handling-tests.result }}" != "success" ] || \
-             [ "${{ needs.output-tests.result }}" != "success" ] || \
-             [ "${{ needs.performance-tests.result }}" != "success" ]; then
+          if [ "$BASIC_RESULT" != "success" ] || \
+             [ "$PRERELEASE_RESULT" != "success" ] || \
+             [ "$EDGE_CASE_RESULT" != "success" ] || \
+             [ "$ERROR_HANDLING_RESULT" != "success" ] || \
+             [ "$OUTPUT_RESULT" != "success" ] || \
+             [ "$PERFORMANCE_RESULT" != "success" ]; then
             echo "❌ Some tests failed!"
             exit 1
           else

--- a/action.yaml
+++ b/action.yaml
@@ -84,20 +84,26 @@ runs:
       if: always()
       shell: bash
       # yamllint disable rule:line-length
+      env:
+        CACHE_HIT: "${{ steps.pip-cache.outputs.cache-hit }}"
+        RUNNER_OS: "${{ runner.os }}"
+        PYPROJECT_HASH: "${{ hashFiles('**/pyproject.toml') }}"
       run: |
-        echo "Cache Hit: ${{ steps.pip-cache.outputs.cache-hit }}"
-        echo "Runner OS: ${{ runner.os }}"
-        echo "Cache Key: ${{ runner.os }}-python-${{ hashFiles('**/pyproject.toml') }}"
+        echo "Cache Hit: $CACHE_HIT"
+        echo "Runner OS: $RUNNER_OS"
+        echo "Cache Key: ${RUNNER_OS}-python-${PYPROJECT_HASH}"
 
     # yamllint disable rule:line-length
     - name: 'Install semantic-tag-increment'
       shell: bash
+      env:
+        ACTION_PATH: "${{ github.action_path }}"
       run: |
         python -m pip install --upgrade pip
 
         # Clean install the package
-        echo "Installing from ${{ github.action_path }}"
-        python -m pip install "${{ github.action_path }}"
+        echo "Installing from $ACTION_PATH"
+        python -m pip install "$ACTION_PATH"
 
     - name: 'Increment semantic tag'
       id: increment


### PR DESCRIPTION
## Summary

Resolves the zizmor **auditor** persona findings (`min-severity: low`)
that fail the organisation's required "Audit Workflows" gate and block
Dependabot pull requests from merging.

## Method

- **Boilerplate workflow** (`release-drafter`) was replaced
  byte-for-byte with the canonical version from `actions-template`.
  This adds harden-runner block-mode egress via
  `harden-runner-block-action` and a documented permission scope
  (`undocumented-permissions`).
- **`codeql.yml`**: leading permission comments converted to trailing
  explanatory comments on each permission line, and the
  `security-events: write` scope documented
  (`undocumented-permissions`).
- **`testing.yaml`**: `persist-credentials: false` added to all six
  checkout steps (`artipacked`); the test-summary step rewritten so
  all `${{ needs.*.result }}` expressions are hoisted into step-level
  environment variables, with the inline `&&`/`||` ternary expressions
  replaced by an equivalent shell helper function
  (`template-injection`).
- **`action.yaml`**: `${{ runner.os }}`, `${{ hashFiles(...) }}`,
  `${{ steps.pip-cache.outputs.cache-hit }}` and
  `${{ github.action_path }}` hoisted out of `run:` blocks into
  step-level environment variables (`template-injection`).

Verified with `zizmor --persona auditor --min-severity low` (clean),
with no action pin downgrades.
